### PR TITLE
message_class

### DIFF
--- a/lib/message.rb
+++ b/lib/message.rb
@@ -1,3 +1,6 @@
+require_relative 'key'
+require_relative 'offset'
+
 class Message
   attr_reader :message, :key, :date
 


### PR DESCRIPTION
Adding require_relative 'key' and 'offset' due to the instantiation of the Key class and Offset classes within the Message class